### PR TITLE
f.submit: Make the same as the value of `data_disable_with` the value of the explicit `:value` option

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -977,6 +977,7 @@ module ActionView
           elsif ActionView::Base.automatically_disable_submit_tag
             disable_with_text = tag_options["data-disable-with"]
             disable_with_text ||= data["disable_with"]
+            disable_with_text ||= tag_options["value"]
             disable_with_text ||= value.to_s.clone
             tag_options.deep_merge!("data" => { "disable_with" => disable_with_text })
           end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -626,6 +626,13 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_submit_tag_with_value_option
+    assert_dom_equal(
+      %(<input data-disable-with="Update" name='commit' type="submit" value="Update" />),
+      submit_tag("Save", value: "Update")
+    )
+  end
+
   def test_empty_submit_tag_with_opt_out
     ActionView::Base.automatically_disable_submit_tag = false
     assert_dom_equal(


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

When you give the value to `f.submit`, the same value sets to the value of `data-disable-with`.

```slim
= f.submit '選択する', class: 'btn btn-primary'
```
```html
<input type="submit" name="commit" value="選択する" class="btn btn-primary" data-disable-with="選択する">
```

But when you give the `:value` option, two values are not the same.

```slim
= f.submit value: '選択する', class: 'btn btn-primary'
```

```html
<input type="submit" name="commit" value="選択する" class="btn btn-primary" data-disable-with="登録する">
```

`登録する` seems to come from i18n as the default value. https://github.com/svenfuchs/rails-i18n/blob/99cfa35268ad20ec1193c670a7ee2a4705140a3d/rails/locale/ja.yml#L145

This PR sets the value of `:value` option to the value of `data-disable-with`
